### PR TITLE
Update Celo Alfajores testnet to Celo Sepolia testnet

### DIFF
--- a/app/rpcdb.js
+++ b/app/rpcdb.js
@@ -386,7 +386,7 @@ const blockchains = [
           "https://celo-sepolia.drpc.org",
           "https://forno.celo-sepolia.celo-testnet.org/"
         ],
-        "chainId": "0xaef3",
+        "chainId": "0xAA044C",
         "nativeCurrency": "CELO",
         "blockExplorer": "https://sepolia.celoscan.io/"
       }

--- a/app/rpcdb.js
+++ b/app/rpcdb.js
@@ -381,14 +381,14 @@ const blockchains = [
         "blockExplorer": "https://celoscan.io/"
       },
       {
-        "network": "Alfajores Testnet",
+        "network": "Celo Sepolia",
         "rpcUrls": [
-          "https://celo-alfajores.drpc.org",
-          "https://alfajores-forno.celo-testnet.org"
+          "https://celo-sepolia.drpc.org",
+          "https://forno.celo-sepolia.celo-testnet.org/"
         ],
         "chainId": "0xaef3",
         "nativeCurrency": "CELO",
-        "blockExplorer": "https://alfajores.celoscan.io/"
+        "blockExplorer": "https://sepolia.celoscan.io/"
       }
     ]
   },


### PR DESCRIPTION
[Celo Sepolia](https://docs.celo.org/infra-partners/notices/celo-sepolia-launch) is a new developer testnet that replaces Alfajores after Holesky sunset in September 2025. 